### PR TITLE
Make noPeak and estimateFragLength executable directly in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ FROM openjdk:11-jre-slim
 RUN apt-get update && apt-get install -y psutils procps && apt-get clean
 COPY --from=build /build/target/NoPeak*.jar /usr/local/lib/noPeak.jar
 COPY estimateFragLength.jar /usr/local/lib/estimateFragLength.jar
+COPY container_scripts/* /bin/
 CMD ["java","-jar","/usr/local/lib/noPeak.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,7 @@ COPY pom.xml /build/pom.xml
 RUN mvn -f /build/pom.xml clean package
 
 FROM openjdk:11-jre-slim
+RUN apt-get update && apt-get install -y psutils procps && apt-get clean
 COPY --from=build /build/target/NoPeak*.jar /usr/local/lib/noPeak.jar
-ENTRYPOINT ["java","-jar","/usr/local/lib/noPeak.jar"]
+COPY estimateFragLength.jar /usr/local/lib/estimateFragLength.jar
+CMD ["java","-jar","/usr/local/lib/noPeak.jar"]

--- a/container_scripts/estimateFragLength
+++ b/container_scripts/estimateFragLength
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+java -jar /usr/local/lib/estimateFragLength.jar "$@"

--- a/container_scripts/noPeak
+++ b/container_scripts/noPeak
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+java -jar /usr/local/lib/noPeak.jar "$@"


### PR DESCRIPTION
Hi! As the headline says, this MR makes it so noPeak and estimateFragLength can be called directly within the container by adding two little bash scripts to /bin.

I've also pulled in psutils and procps to make the container runnable within Nextflow.